### PR TITLE
v2 signatures for protected routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Body
     "data": data, // base64 encoded data
     "encoding": "base64", // how is the data encoded
     "expiry": expiry,
+    "version": 2
 }
 ```
 
@@ -178,6 +179,7 @@ Body
     "data": data, // base64 encoded data
     "encoding": "base64", // how is the data encoded
     "expiry": expiry,
+    "version": 2
 }
 ```
 
@@ -247,6 +249,7 @@ Multi-part form `body`
     "data": data, // base64 encoded data
     "encoding": "base64", // how is the data encoded
     "expiry": expiry,
+    "version": 2
 }
 ```
 
@@ -275,6 +278,7 @@ Body
     "data": data, // base64 encoded data
     "encoding": "base64", // how is the data encoded
     "expiry": expiry,
+    "version": 2
 }
 ```
 

--- a/pkg/router/middleware_test.go
+++ b/pkg/router/middleware_test.go
@@ -1,0 +1,75 @@
+package router
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestSignatureVerification(t *testing.T) {
+	// generate a key pair
+	k, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("legacy", func(t *testing.T) {
+		// make a v0 signed body
+		data := []byte("hello world")
+
+		body := signedBody{
+			Data:     data,
+			Encoding: BodyEncodingBase64,
+			Expiry:   time.Now().Add(time.Second * 5).UnixMilli(),
+		}
+
+		// sign the body
+		sig, err := crypto.Sign(crypto.Keccak256(body.Data), k)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		compactedSig := compactSignature(sig)
+
+		addr := crypto.PubkeyToAddress(k.PublicKey).Hex()
+
+		// verify the signature
+		if !verifySignature(body, addr, compactedSig) {
+			t.Errorf("verifySignature(%v, %s, %s) = false, want true", body, addr, compactedSig)
+		}
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		// make a v0 signed body
+		data := []byte("hello world")
+
+		body := signedBody{
+			Data:     data,
+			Encoding: BodyEncodingBase64,
+			Expiry:   time.Now().Add(time.Second * 5).UnixMilli(),
+			Version:  2,
+		}
+
+		// sign the body
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sig, err := crypto.Sign(crypto.Keccak256(b), k)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		compactedSig := compactSignature(sig)
+
+		addr := crypto.PubkeyToAddress(k.PublicKey).Hex()
+
+		// verify the signature
+		if !verifyV2Signature(body, addr, compactedSig) {
+			t.Errorf("verifySignature(%v, %s, %s) = false, want true", body, addr, compactedSig)
+		}
+	})
+}


### PR DESCRIPTION
v2 signatures also sign the entire body of the request and not just the data. 

When verifying, we also consider the expiry time of the request now. The main reason to do this is so that the expiry time of a request cannot be manipulated.

Temporary support for legacy signature until they get phased out from the apps.