### PR TITLE
Simple Message Queue

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -51,6 +51,8 @@ func main() {
 
 	sync := flag.Int("sync", 5, "sync from block number (default: 5)")
 
+	useropqbf := flag.Int("buffer", 10, "userop queue buffer size (default: 10)")
+
 	ws := flag.Bool("ws", false, "enable websocket")
 
 	onlyAPI := flag.Bool("onlyApi", false, "only run api service")
@@ -172,7 +174,7 @@ func main() {
 
 	op := queue.NewUserOpService(d, evm)
 
-	useropq := queue.NewService("userop", 3, 10, ctx, w)
+	useropq := queue.NewService("userop", 3, *useropqbf, ctx, w)
 
 	go func() {
 		quitAck <- useropq.Start(op)

--- a/internal/services/db/transfer.go
+++ b/internal/services/db/transfer.go
@@ -294,6 +294,15 @@ func (db *TransferDB) TransferSimilarExists(from, to, value string) (string, err
 	return hash, nil
 }
 
+// RemoveTransfer removes a sending transfer from the db
+func (db *TransferDB) RemoveTransfer(hash string) error {
+	_, err := db.db.Exec(fmt.Sprintf(`
+	DELETE FROM t_transfers_%s WHERE hash = $1 AND status != 'success'
+	`, db.suffix), hash)
+
+	return err
+}
+
 // RemoveSendingTransfer removes a sending transfer from the db
 func (db *TransferDB) RemoveSendingTransfer(hash string) error {
 	_, err := db.db.Exec(fmt.Sprintf(`

--- a/internal/services/webhook/webhook.go
+++ b/internal/services/webhook/webhook.go
@@ -54,6 +54,33 @@ func (b *Messager) Notify(ctx context.Context, message string) error {
 	return nil
 }
 
+func (b *Messager) NotifyWarning(ctx context.Context, errorMessage error) error {
+	data, err := json.Marshal(Message{Content: fmt.Sprintf("[%s] warning: %s", b.ChainName, errorMessage.Error())})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.BaseURL, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("error sending message")
+	}
+
+	return nil
+}
+
 func (b *Messager) NotifyError(ctx context.Context, errorMessage error) error {
 	data, err := json.Marshal(Message{Content: fmt.Sprintf("[%s] error: %s", b.ChainName, errorMessage.Error())})
 	if err != nil {

--- a/internal/services/webhook/webhook.go
+++ b/internal/services/webhook/webhook.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/citizenwallet/indexer/pkg/indexer"
 )
 
 type Message struct {
@@ -18,7 +20,7 @@ type Messager struct {
 	ChainName string
 }
 
-func NewMessager(baseURL, chainName string) *Messager {
+func NewMessager(baseURL, chainName string) indexer.WebhookMessager {
 	return &Messager{
 		BaseURL:   baseURL,
 		ChainName: chainName,

--- a/internal/userop/handlers.go
+++ b/internal/userop/handlers.go
@@ -3,38 +3,37 @@ package userop
 import (
 	"bytes"
 	"context"
-	"crypto/ecdsa"
 	"encoding/json"
 	"math/big"
 	"net/http"
-	"strings"
 	"time"
 
 	comm "github.com/citizenwallet/indexer/internal/common"
 	"github.com/citizenwallet/indexer/internal/services/db"
 	"github.com/citizenwallet/indexer/pkg/indexer"
+	"github.com/citizenwallet/indexer/pkg/queue"
 	pay "github.com/citizenwallet/smartcontracts/pkg/contracts/paymaster"
 	"github.com/citizenwallet/smartcontracts/pkg/contracts/tokenEntryPoint"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/go-chi/chi/v5"
 )
 
 type Service struct {
 	evm     indexer.EVMRequester
 	db      *db.DB
+	useropq *queue.Service
 	chainId *big.Int
 }
 
 // NewService
-func NewService(evm indexer.EVMRequester, db *db.DB, chid *big.Int) *Service {
+func NewService(evm indexer.EVMRequester, db *db.DB, useropq *queue.Service, chid *big.Int) *Service {
 	return &Service{
 		evm,
 		db,
+		useropq,
 		chid,
 	}
 }
@@ -199,10 +198,10 @@ func (s *Service) Send(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the public key from the private key
-	publicKey := privateKey.Public().(*ecdsa.PublicKey)
+	// publicKey := privateKey.Public().(*ecdsa.PublicKey)
 
 	// Convert the public key to an Ethereum address
-	sponsor := crypto.PubkeyToAddress(*publicKey)
+	// sponsor := crypto.PubkeyToAddress(*publicKey)
 
 	entryPoint := common.HexToAddress(epAddr)
 
@@ -220,105 +219,12 @@ func (s *Service) Send(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	nonce, err := s.evm.NonceAt(context.Background(), sponsor, nil)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+	// Create a new message
+	message := indexer.NewTxMessage(addr, entryPoint, data, s.chainId, userop)
 
-	// TODO: needs a queue system to avoid nonce collisions when submitting multiple transactions
+	// Enqueue the message
+	s.useropq.Enqueue(*message)
 
-	tx, err := s.evm.NewTx(nonce, sponsor, entryPoint, data)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	chainId, err := s.evm.ChainID()
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	// Sign the transaction
-	signedTx, err := types.SignTx(tx, types.NewLondonSigner(chainId), privateKey)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	// detect if this userop is a transfer using the calldata
-	// Parse the contract ABI
-	var tdb *db.TransferDB
-	var log *indexer.Transfer
-
-	dest, toaddr, amount, parseErr := comm.ParseERC20Transfer(userop.CallData)
-	if parseErr == nil {
-		// this is an erc20 transfer
-		log = &indexer.Transfer{
-			TokenID:   0,
-			CreatedAt: time.Now(),
-			From:      userop.Sender.Hex(),
-			To:        toaddr.Hex(), //
-			Nonce:     userop.Nonce.Int64(),
-			Value:     amount,
-			Status:    indexer.TransferStatusSending,
-		}
-
-		log.FromTo = log.CombineFromTo()
-
-		log.GenerateTempHash(s.chainId.Int64())
-
-		tdb, ok = s.db.TransferDB[s.db.TransferName(dest.Hex())]
-		if ok {
-			tdb.AddTransfer(log)
-		}
-	}
-
-	err = s.evm.SendTransaction(signedTx)
-	if err != nil {
-		e, ok := err.(rpc.Error)
-		if ok && e.ErrorCode() != -32000 {
-			if parseErr == nil && tdb != nil && log != nil {
-				tdb.RemoveSendingTransfer(log.Hash)
-			}
-
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		if !strings.Contains(e.Error(), "insufficient funds") {
-			if parseErr == nil && tdb != nil && log != nil {
-				tdb.RemoveSendingTransfer(log.Hash)
-			}
-
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		if parseErr == nil && tdb != nil && log != nil {
-			tdb.RemoveSendingTransfer(log.Hash)
-		}
-
-		// insufficient funds
-		w.WriteHeader(http.StatusPreconditionFailed)
-		return
-	}
-
-	if parseErr == nil && tdb != nil && log != nil {
-		err = tdb.SetFinalHash(signedTx.Hash().Hex(), log.Hash)
-		if err != nil {
-			tdb.RemoveSendingTransfer(log.Hash)
-
-			comm.JSONRPCBody(w, signedTx.Hash().Hex(), nil)
-			return
-		}
-
-		err = tdb.SetStatus(string(indexer.TransferStatusSending), signedTx.Hash().Hex())
-		if err != nil {
-			tdb.RemoveSendingTransfer(log.Hash)
-		}
-	}
-
-	comm.JSONRPCBody(w, signedTx.Hash().Hex(), nil)
+	// Return the message ID
+	comm.JSONRPCBody(w, message.ID, nil)
 }

--- a/internal/userop/handlers.go
+++ b/internal/userop/handlers.go
@@ -197,12 +197,6 @@ func (s *Service) Send(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the public key from the private key
-	// publicKey := privateKey.Public().(*ecdsa.PublicKey)
-
-	// Convert the public key to an Ethereum address
-	// sponsor := crypto.PubkeyToAddress(*publicKey)
-
 	entryPoint := common.HexToAddress(epAddr)
 
 	// Parse the contract ABI

--- a/pkg/indexer/queue.go
+++ b/pkg/indexer/queue.go
@@ -1,0 +1,38 @@
+package indexer
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type Message struct {
+	ID         string
+	CreatedAt  time.Time
+	RetryCount int
+	Message    any
+}
+
+type TxMessage struct {
+	From common.Address
+	To   common.Address
+	Data []byte
+}
+
+func newMessage(message any) *Message {
+	return &Message{
+		ID:         RandomString(32),
+		CreatedAt:  time.Now(),
+		RetryCount: 0,
+		Message:    message,
+	}
+}
+
+func NewTxMessage(from, to common.Address, data []byte) *Message {
+	tx := &TxMessage{
+		From: from,
+		To:   to,
+		Data: data,
+	}
+	return newMessage(tx)
+}

--- a/pkg/indexer/queue.go
+++ b/pkg/indexer/queue.go
@@ -29,7 +29,7 @@ func newMessage(message any) *Message {
 }
 
 func NewTxMessage(from, to common.Address, data []byte) *Message {
-	tx := &TxMessage{
+	tx := TxMessage{
 		From: from,
 		To:   to,
 		Data: data,

--- a/pkg/indexer/queue.go
+++ b/pkg/indexer/queue.go
@@ -13,10 +13,11 @@ type Message struct {
 	Message    any
 }
 
-type TxMessage struct {
-	From common.Address
-	To   common.Address
-	Data []byte
+type UserOpMessage struct {
+	Paymaster common.Address
+	To        common.Address
+	Data      []byte
+	UserOp    UserOp
 }
 
 func newMessage(message any) *Message {
@@ -28,11 +29,12 @@ func newMessage(message any) *Message {
 	}
 }
 
-func NewTxMessage(from, to common.Address, data []byte) *Message {
-	tx := TxMessage{
-		From: from,
-		To:   to,
-		Data: data,
+func NewTxMessage(pm, to common.Address, data []byte, userop UserOp) *Message {
+	tx := UserOpMessage{
+		Paymaster: pm,
+		To:        to,
+		Data:      data,
+		UserOp:    userop,
 	}
 	return newMessage(tx)
 }

--- a/pkg/indexer/queue.go
+++ b/pkg/indexer/queue.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -17,24 +18,26 @@ type UserOpMessage struct {
 	Paymaster common.Address
 	To        common.Address
 	Data      []byte
+	ChainId   *big.Int
 	UserOp    UserOp
 }
 
-func newMessage(message any) *Message {
+func newMessage(id string, message any) *Message {
 	return &Message{
-		ID:         RandomString(32),
+		ID:         id,
 		CreatedAt:  time.Now(),
 		RetryCount: 0,
 		Message:    message,
 	}
 }
 
-func NewTxMessage(pm, to common.Address, data []byte, userop UserOp) *Message {
-	tx := UserOpMessage{
+func NewTxMessage(pm, to common.Address, data []byte, chainId *big.Int, userop UserOp) *Message {
+	op := UserOpMessage{
 		Paymaster: pm,
 		To:        to,
 		Data:      data,
+		ChainId:   chainId,
 		UserOp:    userop,
 	}
-	return newMessage(tx)
+	return newMessage(common.Bytes2Hex(userop.Signature), op)
 }

--- a/pkg/indexer/utils.go
+++ b/pkg/indexer/utils.go
@@ -1,0 +1,23 @@
+package indexer
+
+import (
+	"math/rand"
+	"time"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyz" +
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func StringWithCharset(length int, charset string) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[r.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func RandomString(length int) string {
+	return StringWithCharset(length, charset)
+}

--- a/pkg/indexer/webhook.go
+++ b/pkg/indexer/webhook.go
@@ -4,5 +4,6 @@ import "context"
 
 type WebhookMessager interface {
 	Notify(ctx context.Context, message string) error
+	NotifyWarning(ctx context.Context, errorMessage error) error
 	NotifyError(ctx context.Context, errorMessage error) error
 }

--- a/pkg/indexer/webhook.go
+++ b/pkg/indexer/webhook.go
@@ -1,0 +1,8 @@
+package indexer
+
+import "context"
+
+type WebhookMessager interface {
+	Notify(ctx context.Context, message string) error
+	NotifyError(ctx context.Context, errorMessage error) error
+}

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -43,7 +43,8 @@ func NewService(name string, maxRetries, bufferSize int, ctx context.Context, wm
 // Enqueue method enqueues a message to the queue channel.
 func (s *Service) Enqueue(message indexer.Message) {
 	// if the queue channel is almost full, notify the webhook messager with a warning notification
-	if len(s.queue) > (s.bufferSize / 10) {
+	bufferWarning := s.bufferSize - (s.bufferSize / 10)
+	if len(s.queue) > bufferWarning {
 		s.wm.NotifyWarning(s.ctx, errors.New(fmt.Sprintf("%s queue is almost full", s.name)))
 	}
 

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -7,52 +7,57 @@ import (
 	"github.com/citizenwallet/indexer/pkg/indexer"
 )
 
+// Service struct represents a queue service with a queue channel, quit channel, maximum retries, context and a webhook messager.
 type Service struct {
-	queue      chan indexer.Message
-	quit       chan bool
-	maxRetries int
+	queue      chan indexer.Message // Channel to enqueue messages
+	quit       chan bool            // Channel to signal service to stop
+	maxRetries int                  // Maximum number of retries for processing a message
 
-	ctx context.Context
-	wm  indexer.WebhookMessager
+	ctx context.Context         // Context to carry deadlines, cancellation signals, and other request-scoped values across API boundaries and between processes
+	wm  indexer.WebhookMessager // Webhook messager to notify errors
 }
 
+// Processor is an interface that must be implemented by the consumer of the queue
 type Processor interface {
-	Process(indexer.Message) error
+	Process(indexer.Message) error // Process method to process a message
 }
 
+// NewService function initializes a new Service with provided maximum retries, context and webhook messager.
 func NewService(maxRetries int, ctx context.Context, wm indexer.WebhookMessager) *Service {
 	return &Service{
-		queue:      make(chan indexer.Message),
-		quit:       make(chan bool),
-		maxRetries: maxRetries,
-		ctx:        ctx,
-		wm:         wm,
+		queue:      make(chan indexer.Message), // Initialize the queue channel
+		quit:       make(chan bool),            // Initialize the quit channel
+		maxRetries: maxRetries,                 // Set the maximum retries
+		ctx:        ctx,                        // Set the context
+		wm:         wm,                         // Set the webhook messager
 	}
 }
 
+// Enqueue method enqueues a message to the queue channel.
 func (s *Service) Enqueue(message indexer.Message) {
 	s.queue <- message
 }
 
+// Close method sends a signal to the quit channel to stop the service.
 func (s *Service) Close() {
 	s.quit <- true
 }
 
+// Start method starts the service and processes messages from the queue channel.
+// If processing a message fails, it requeues the message until the maximum retries is reached.
+// If the queue was empty, it waits for a duration before continuing to avoid a busy loop.
+// It also notifies errors using the webhook messager.
+// The service can be stopped by sending a signal to the quit channel.
 func (s *Service) Start(p Processor) error {
 	for {
 		select {
 		case message := <-s.queue:
-			// process an item in the queue
-			// it is up to the processor to handle the data type
 			err := p.Process(message)
 			if err != nil {
-				// if there is an error, requeue the message
 				if message.RetryCount < s.maxRetries {
 					message.RetryCount++
 					s.queue <- message
 					if len(s.queue) == 1 {
-						// if the queue was empty, we need to wait a bit
-						// to avoid a busy loop
 						extraWait := time.Duration(message.RetryCount) * time.Second
 						time.Sleep(extraWait)
 					}
@@ -62,7 +67,6 @@ func (s *Service) Start(p Processor) error {
 				s.wm.NotifyError(s.ctx, err)
 			}
 		case <-s.quit:
-			// quit the service
 			return nil
 		}
 	}

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -70,7 +70,6 @@ func (s *Service) Start(p Processor) error {
 	for {
 		select {
 		case message := <-s.queue:
-			log.Default().Println("processing message")
 			msg, err := p.Process(message)
 			if err != nil {
 				if msg.RetryCount < s.maxRetries {

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,22 +1,32 @@
 package queue
 
-import "github.com/citizenwallet/indexer/pkg/indexer"
+import (
+	"context"
+	"time"
+
+	"github.com/citizenwallet/indexer/pkg/indexer"
+)
 
 type Service struct {
 	queue      chan indexer.Message
 	quit       chan bool
 	maxRetries int
+
+	ctx context.Context
+	wm  indexer.WebhookMessager
 }
 
 type Processor interface {
 	Process(indexer.Message) error
 }
 
-func NewService(maxRetries int) *Service {
+func NewService(maxRetries int, ctx context.Context, wm indexer.WebhookMessager) *Service {
 	return &Service{
 		queue:      make(chan indexer.Message),
 		quit:       make(chan bool),
 		maxRetries: maxRetries,
+		ctx:        ctx,
+		wm:         wm,
 	}
 }
 
@@ -40,9 +50,16 @@ func (s *Service) Start(p Processor) error {
 				if message.RetryCount < s.maxRetries {
 					message.RetryCount++
 					s.queue <- message
+					if len(s.queue) == 1 {
+						// if the queue was empty, we need to wait a bit
+						// to avoid a busy loop
+						extraWait := time.Duration(message.RetryCount) * time.Second
+						time.Sleep(extraWait)
+					}
 					continue
 				}
-				return err
+
+				s.wm.NotifyError(s.ctx, err)
 			}
 		case <-s.quit:
 			// quit the service

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/citizenwallet/indexer/pkg/indexer"
@@ -65,9 +66,11 @@ func (s *Service) Close() {
 // It also notifies errors using the webhook messager.
 // The service can be stopped by sending a signal to the quit channel.
 func (s *Service) Start(p Processor) error {
+	log.Default().Println(fmt.Sprintf("starting queue service '%s'", s.name))
 	for {
 		select {
 		case message := <-s.queue:
+			log.Default().Println("processing message")
 			msg, err := p.Process(message)
 			if err != nil {
 				if msg.RetryCount < s.maxRetries {
@@ -87,6 +90,7 @@ func (s *Service) Start(p Processor) error {
 				}
 			}
 		case <-s.quit:
+			log.Default().Println(fmt.Sprintf("stopping queue service '%s'", s.name))
 			return nil
 		}
 	}

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,0 +1,52 @@
+package queue
+
+import "github.com/citizenwallet/indexer/pkg/indexer"
+
+type Service struct {
+	queue      chan indexer.Message
+	quit       chan bool
+	maxRetries int
+}
+
+type Processor interface {
+	Process(indexer.Message) error
+}
+
+func NewService(maxRetries int) *Service {
+	return &Service{
+		queue:      make(chan indexer.Message),
+		quit:       make(chan bool),
+		maxRetries: maxRetries,
+	}
+}
+
+func (s *Service) Enqueue(message indexer.Message) {
+	s.queue <- message
+}
+
+func (s *Service) Close() {
+	s.quit <- true
+}
+
+func (s *Service) Start(p Processor) error {
+	for {
+		select {
+		case message := <-s.queue:
+			// process an item in the queue
+			// it is up to the processor to handle the data type
+			err := p.Process(message)
+			if err != nil {
+				// if there is an error, requeue the message
+				if message.RetryCount < s.maxRetries {
+					message.RetryCount++
+					s.queue <- message
+					continue
+				}
+				return err
+			}
+		case <-s.quit:
+			// quit the service
+			return nil
+		}
+	}
+}

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -22,7 +22,7 @@ type TestTxProcessor struct {
 func (p *TestTxProcessor) Process(message indexer.Message) (indexer.Message, error) {
 	defer func() { p.count++ }()
 
-	_, ok := message.Message.(indexer.TxMessage)
+	_, ok := message.Message.(indexer.UserOpMessage)
 	if !ok {
 		return message, p.expectedError
 	}
@@ -59,12 +59,12 @@ func TestProcessMessages(t *testing.T) {
 
 	t.Run("TxMessages", func(t *testing.T) {
 		testCases := []indexer.Message{
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
 		}
 
 		m := &TestTxMessager{t, expectedTxError}
@@ -99,12 +99,12 @@ func TestProcessMessages(t *testing.T) {
 
 	t.Run("TxMessages with 1 invalid", func(t *testing.T) {
 		testCases := []indexer.Message{
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
 			{ID: "invalid", CreatedAt: time.Now(), RetryCount: 0, Message: "invalid"},
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
 		}
 
 		m := &TestTxMessager{t, expectedTxError}

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -59,12 +59,12 @@ func TestProcessMessages(t *testing.T) {
 
 	t.Run("TxMessages", func(t *testing.T) {
 		testCases := []indexer.Message{
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
 		}
 
 		m := &TestTxMessager{t, expectedTxError}
@@ -99,12 +99,12 @@ func TestProcessMessages(t *testing.T) {
 
 	t.Run("TxMessages with 1 invalid", func(t *testing.T) {
 		testCases := []indexer.Message{
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
 			{ID: "invalid", CreatedAt: time.Now(), RetryCount: 0, Message: "invalid"},
-			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, indexer.UserOp{}),
+			*indexer.NewTxMessage(common.Address{}, common.Address{}, []byte{}, common.Big0, indexer.UserOp{}),
 		}
 
 		m := &TestTxMessager{t, expectedTxError}

--- a/pkg/queue/userop.go
+++ b/pkg/queue/userop.go
@@ -1,0 +1,147 @@
+package queue
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"strings"
+	"time"
+
+	comm "github.com/citizenwallet/indexer/internal/common"
+	"github.com/citizenwallet/indexer/internal/services/db"
+	"github.com/citizenwallet/indexer/pkg/indexer"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type TxService struct {
+	db  *db.DB
+	evm indexer.EVMRequester
+}
+
+func NewTxService() *TxService {
+	return &TxService{}
+}
+
+// Process method processes a message of type indexer.Message and returns a processed message and an error if any.
+func (s *TxService) Process(message indexer.Message) (indexer.Message, error) {
+	// Type assertion to check if the message is of type indexer.UserOpMessage
+	txm, ok := message.Message.(indexer.UserOpMessage)
+	if !ok {
+		// If the message is not of type indexer.UserOpMessage, return an error
+		return message, errors.New("invalid tx message")
+	}
+
+	// Fetch the sponsor's corresponding private key from the database
+	sponsorKey, err := s.db.SponsorDB.GetSponsor(txm.Paymaster.Hex())
+	if err != nil {
+		return message, err
+	}
+
+	// Generate ecdsa.PrivateKey from bytes
+	privateKey, err := comm.HexToPrivateKey(sponsorKey.PrivateKey)
+	if err != nil {
+		return message, err
+	}
+
+	// Get the public key from the private key
+	publicKey := privateKey.Public().(*ecdsa.PublicKey)
+
+	// Convert the public key to an Ethereum address
+	sponsor := crypto.PubkeyToAddress(*publicKey)
+
+	// Get the nonce for the sponsor's address
+	nonce, err := s.evm.NonceAt(context.Background(), sponsor, nil)
+	if err != nil {
+		return message, err
+	}
+
+	// Create a new transaction
+	tx, err := s.evm.NewTx(nonce, sponsor, txm.To, txm.Data)
+	if err != nil {
+		return message, err
+	}
+
+	// Get the chain ID
+	chainId, err := s.evm.ChainID()
+	if err != nil {
+		return message, err
+	}
+
+	// Sign the transaction
+	signedTx, err := types.SignTx(tx, types.NewLondonSigner(chainId), privateKey)
+	if err != nil {
+		return message, err
+	}
+
+	// Detect if this user operation is a transfer using the call data
+	// Parse the contract ABI
+	var tdb *db.TransferDB
+	var log *indexer.Transfer
+
+	userop := txm.UserOp
+
+	// Parse the ERC20 transfer from the call data
+	dest, toaddr, amount, parseErr := comm.ParseERC20Transfer(userop.CallData)
+	if parseErr == nil {
+		// If the parsing is successful, this is an ERC20 transfer
+		// Create a new transfer log
+		log = &indexer.Transfer{
+			TokenID:   0,
+			CreatedAt: time.Now(),
+			From:      userop.Sender.Hex(),
+			To:        toaddr.Hex(),
+			Nonce:     userop.Nonce.Int64(),
+			Value:     amount,
+			Status:    indexer.TransferStatusSending,
+		}
+
+		// Combine the From and To addresses into a single string
+		log.FromTo = log.CombineFromTo()
+
+		// Generate a temporary hash for the transfer
+		log.GenerateTempHash(chainId.Int64())
+
+		// Get the transfer database for the destination address
+		tdb, ok = s.db.TransferDB[s.db.TransferName(dest.Hex())]
+		if ok {
+			// If the transfer database exists, add the transfer log to it
+			tdb.AddTransfer(log)
+		}
+	}
+
+	// Send the signed transaction
+	err = s.evm.SendTransaction(signedTx)
+	if err != nil {
+		// If there's an error, check if it's an RPC error
+		e, ok := err.(rpc.Error)
+		if ok && e.ErrorCode() != -32000 {
+			// If it's an RPC error and the error code is not -32000, remove the sending transfer and return the error
+			if parseErr == nil && tdb != nil && log != nil {
+				tdb.RemoveSendingTransfer(log.Hash)
+			}
+
+			return message, err
+		}
+
+		if !strings.Contains(e.Error(), "insufficient funds") {
+			// If the error is not about insufficient funds, remove the sending transfer and return the error
+			if parseErr == nil && tdb != nil && log != nil {
+				tdb.RemoveSendingTransfer(log.Hash)
+			}
+
+			return message, err
+		}
+
+		if parseErr == nil && tdb != nil && log != nil {
+			// If there are insufficient funds, set the status of the transfer to fail
+			tdb.SetStatus(log.Hash, string(indexer.TransferStatusFail))
+		}
+
+		// Return the error about insufficient funds
+		return message, err
+	}
+
+	return indexer.Message{}, nil
+}


### PR DESCRIPTION
Message Queue:
- FIFO
- Buffered - fill up the queue to a certain amount, then block
- Notify with warning or error that a queue is reaching its limit
- In-memory
- Retry until max count - insert to back of the queue (safety check to avoid a busy loop) 
- Leave message processing implementation to service initiator

UserOp Processor:
- Fetch sponsor from the db
- Fetch nonce for sponsor
- Sign and submit
- Wait to be mined
- Insert transactions in the db depending on submission state